### PR TITLE
Fix letterboxd review sort order

### DIFF
--- a/lib/letterboxd.ts
+++ b/lib/letterboxd.ts
@@ -89,8 +89,9 @@ export function mergeEntries(
   const map = new Map<string, WatchEntry>();
   for (const entry of existing) map.set(key(entry), entry);
   for (const entry of incoming) map.set(key(entry), entry);
-  return Array.from(map.values()).sort(
-    (a, b) =>
-      new Date(b.watchedDate).getTime() - new Date(a.watchedDate).getTime(),
-  );
+  return Array.from(map.values()).sort((a, b) => {
+    const ta = new Date(a.watchedDate).getTime() || 0;
+    const tb = new Date(b.watchedDate).getTime() || 0;
+    return tb - ta;
+  });
 }


### PR DESCRIPTION
## What's new

- Fixed sort comparator in `mergeEntries` to handle entries with invalid/empty `watchedDate` values
- Entries now consistently appear in correct date order (newest first)

## Root cause

The sort comparator used `new Date(watchedDate).getTime()` directly, which returns `NaN` when `watchedDate` is empty. This broke JavaScript's sort algorithm by violating transitivity, causing entries to end up in arbitrary positions—including new reviews appearing at the end of the list instead of the top.

## This change is

- [x] QA: Nothing to test (lint passed, TypeScript compiled successfully)
